### PR TITLE
Remove |render from column layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ Thumbs.db
 .idea/
 public
 dependencyGraph.json
-dist
 source/css/style.css
 source/css/.sass-cache/*

--- a/source/_patterns/01-molecules/01-layout/four-column.twig
+++ b/source/_patterns/01-molecules/01-layout/four-column.twig
@@ -7,34 +7,33 @@
   ]
 %}
 
-{% if content|render %}
-  <div class="{{ background_class }}">
-    <div{{ attributes.addClass(classes) }}>
+<div class="{{ background_class }}">
+  <div{{ attributes.addClass(classes) }}>
 
-      {% if content.first %}
-        <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
-          {{ content.first }}
-        </div>
-      {% endif %}
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
 
-      {% if content.second %}
-        <div {{ region_attributes.second.addClass('qh-layout-section__col', 'qh-layout-section__col--second') }}>
-          {{ content.second }}
-        </div>
-      {% endif %}
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass('qh-layout-section__col', 'qh-layout-section__col--second') }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
 
-      {% if content.third %}
-        <div {{ region_attributes.third.addClass('qh-layout-section__col', 'qh-layout-section__col--third') }}>
-          {{ content.third }}
-        </div>
-      {% endif %}
+    {% if content.third %}
+      <div {{ region_attributes.third.addClass('qh-layout-section__col', 'qh-layout-section__col--third') }}>
+        {{ content.third }}
+      </div>
+    {% endif %}
 
-      {% if content.fourth %}
-        <div {{ region_attributes.fourth.addClass('qh-layout-section__col', 'qh-layout-section__col--fourth') }}>
-          {{ content.fourth }}
-        </div>
-      {% endif %}
+    {% if content.fourth %}
+      <div {{ region_attributes.fourth.addClass('qh-layout-section__col', 'qh-layout-section__col--fourth') }}>
+        {{ content.fourth }}
+      </div>
+    {% endif %}
 
-    </div>
   </div>
-{% endif %}
+</div>
+

--- a/source/_patterns/01-molecules/01-layout/one-column.twig
+++ b/source/_patterns/01-molecules/01-layout/one-column.twig
@@ -7,16 +7,14 @@
   ]
 %}
 
-{% if content|render %}
-  <div class="{{ background_class }}">
-    <div{{ attributes.addClass(classes) }}>
+<div class="{{ background_class }}">
+  <div{{ attributes.addClass(classes) }}>
 
-      {% if content.first %}
-        <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
-          {{ content.first }}
-        </div>
-      {% endif %}
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
 
-    </div>
   </div>
-{% endif %}
+</div>

--- a/source/_patterns/01-molecules/01-layout/three-column.twig
+++ b/source/_patterns/01-molecules/01-layout/three-column.twig
@@ -7,28 +7,26 @@
   ]
 %}
 
-{% if content|render %}
-  <div class="{{ background_class }}">
-    <div{{ attributes.addClass(classes) }}>
+<div class="{{ background_class }}">
+  <div{{ attributes.addClass(classes) }}>
 
-      {% if content.first %}
-        <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
-          {{ content.first }}
-        </div>
-      {% endif %}
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
 
-      {% if content.second %}
-        <div {{ region_attributes.second.addClass('qh-layout-section__col', 'qh-layout-section__col--second') }}>
-          {{ content.second }}
-        </div>
-      {% endif %}
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass('qh-layout-section__col', 'qh-layout-section__col--second') }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
 
-      {% if content.third %}
-        <div {{ region_attributes.third.addClass('qh-layout-section__col', 'qh-layout-section__col--third') }}>
-          {{ content.third }}
-        </div>
-      {% endif %}
+    {% if content.third %}
+      <div {{ region_attributes.third.addClass('qh-layout-section__col', 'qh-layout-section__col--third') }}>
+        {{ content.third }}
+      </div>
+    {% endif %}
 
-    </div>
   </div>
-{% endif %}
+</div>

--- a/source/_patterns/01-molecules/01-layout/two-column.twig
+++ b/source/_patterns/01-molecules/01-layout/two-column.twig
@@ -7,21 +7,20 @@
   ]
 %}
 
-{% if content|render %}
-  <div class="{{ background_class }}">
-    <div{{ attributes.addClass(classes) }}>
+<div class="{{ background_class }}">
+  <div{{ attributes.addClass(classes) }}>
 
-      {% if content.first %}
-        <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
-          {{ content.first }}
-        </div>
-      {% endif %}
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass('qh-layout-section__col', 'qh-layout-section__col--first') }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
 
-      {% if content.second %}
-        <div {{ region_attributes.second.addClass('qh-layout-section__col', 'qh-layout-section__col--second') }}>
-          {{ content.second }}
-        </div>
-      {% endif %}
-    </div>
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass('qh-layout-section__col', 'qh-layout-section__col--second') }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
   </div>
-{% endif %}
+</div>
+


### PR DESCRIPTION
## Summary
`|render` is not a universal twig function and was causing PL to error out. This PR removes those calls.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-37
