### PR TITLE
Remove t function from file.twig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Deprecated
 
 ### Removed
+- RIG-130 - Removed t function from file twig.
 
 ### Fixed
 

--- a/source/_patterns/01-molecules/file/file.twig
+++ b/source/_patterns/01-molecules/file/file.twig
@@ -29,7 +29,8 @@
     <div class="qh__file-list__item__filename">
       <span class="qh__file-list__item__label">{{ name }}</span>
       {# Intent for file size: If it is less than 1mb, simplify the text to "less than 1mb" #}
-      <span class="qh__file-list__item__filesize">{{ file_type_readable|t }}, {{ file_size.amount|t }}<span aria-hidden="true">{{ file_size.short_format }}</span><span class="visually-hidden">{{ file_size.long_format }}</span></span>
+      {# TODO: Add translation #}
+      <span class="qh__file-list__item__filesize">{{ file_type_readable }}, {{ file_size.amount }}<span aria-hidden="true">{{ file_size.short_format }}</span><span class="visually-hidden">{{ file_size.long_format }}</span></span>
     </div>
     <div class="qh__file-list__item__download">
       <span class="qh__icon">


### PR DESCRIPTION
## Summary
Switching the t function to be here has caused the following error:
` > InvalidArgumentException: $string ("less than 1") must be a string. in Drupal\Core\StringTranslation\TranslatableMarkup->__construct() (line 132 of /mnt/www/html/riecms01live/docroot/core/lib/Drupal/Core/StringTranslation/TranslatableMarkup.php).
`
We're removing it for the time-being to see what the right way to do this is. 

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-130
