### PR TITLE
Remove the raw filter from the page footer output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+- RIG-180: Removed the raw twig filter from the footer.
 
 ## [0.3.4] - 2020-12-11
 - RIG-130: Heading max size tweaks.

--- a/source/_patterns/02-organisms/page-footer/page-footer.twig
+++ b/source/_patterns/02-organisms/page-footer/page-footer.twig
@@ -1,16 +1,16 @@
 <footer class="qh__site-footer" role="contentinfo">
   <div class="qh__site-footer__inner">
     <div class="qh__site-footer__content qh__site-footer__first">
-      {{ footer_preprocess_values.footer_left|raw }}
+      {{ footer_preprocess_values.footer_left }}
     </div>
     <div class="qh__site-footer__content qh__site-footer__second">
-      {{ footer_preprocess_values.footer_center|raw }}
+      {{ footer_preprocess_values.footer_center }}
     </div>
     <div class="qh__site-footer__content qh__site-footer__third">
-      {{ footer_preprocess_values.footer_right|raw }}
+      {{ footer_preprocess_values.footer_right }}
     </div>
     <div class="qh__site-footer__content qh__site-footer__fourth">
-      {{ footer_preprocess_values.state_info|raw }}
+      {{ footer_preprocess_values.state_info }}
     </div>
   </div>
   <div class="qh__site-footer__copyright">


### PR DESCRIPTION
## Summary
The raw filter in conjunction with the preprocess function was allowing an XSS vulnerability. This fix is in conjunction [with this profile PR](https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/pull/162) to properly sanitize the output of the theme configuration variables.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-180](https://thinkoomph.jira.com/browse/rig-180)
