### PR TITLE
Fix reoccurring attributes error message appearing in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-195: Fixed reoccurring attributes error message appearing in search.
 
 ### Security
 

--- a/source/_patterns/02-organisms/articles-list/articles-list.twig
+++ b/source/_patterns/02-organisms/articles-list/articles-list.twig
@@ -7,9 +7,14 @@
     </div>
   {% endif %}
 
-  <div class="qh__articles-list__list">
-    {{ rows }}
-  </div>
+  {% if rows %}
+    <div class="qh__articles-list__list">
+      {% for row in rows %}
+        {{- row.content -}}
+      {% endfor %}
+    </div>
+  {% endif %}
+
   {% if pager %}
     {{ pager }}
   {% endif %}


### PR DESCRIPTION
## Summary
This PR fixes an error that kept appearing in log re: attributes not being a valid render attribute. We were printing the entire rows object rather than just row.content.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you perform a self review first? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-195
