### PR TITLE
Fix encoding in meta title tag and press release teasers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-30: Fixed encoding in HTML title tag.
+- RIGA-30: Fixed encoding in press release teasers and add ellipsis to summary text.
 
 ### Security
 

--- a/source/_patterns/01-molecules/teaser-article/teaser-article.twig
+++ b/source/_patterns/01-molecules/teaser-article/teaser-article.twig
@@ -7,7 +7,9 @@
   </header>
   <div class="qh__teaser-article__content">
     {% if excerpt | length > 0 %}
-    <p class="qh__teaser-article__excerpt">{{ excerpt }}</p>
+      {% autoescape false %}
+        <p class="qh__teaser-article__excerpt">{{ excerpt|length > 190 ? excerpt|slice(0, 190) ~ '...' : excerpt }}</p>
+      {% endautoescape %}
     {% endif %}
     {% include "@molecules/cta-read-more/cta-read-more.twig" with {
       cta_read_text: alt_read_text,

--- a/source/_patterns/03-templates/00-layouts/_html.html.pl.twig
+++ b/source/_patterns/03-templates/00-layouts/_html.html.pl.twig
@@ -28,7 +28,9 @@
 <html{{ html_attributes.addClass(palette) }}>
   <head>
     <head-placeholder token="{{ placeholder_token }}">
-    <title>{{ head_title }}</title>
+    {% autoescape false %}
+      <title>{{ head_title }}</title>
+    {% endautoescape %}
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
     <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="/profiles/contrib/ecms_profile/ecms_base/themes/custom/ecms/ecms_patternlab/dist/vendor/ie11CustomProperties.min.js"><\/script>');</script>


### PR DESCRIPTION
## Summary
This PR fixes encoding in the meta title tag and press release teasers. It also appends an ellipsis after 190 characters of the teaser summary.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-30
